### PR TITLE
Fixed setdefault method to return the value that was set/found

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ Pending Release
 * Stopped including the 'tests' directory in package
 * Django 1.8 and 1.9 supported.
 * Python 3 support added.
+* Fixed ``setdefault()`` to return the value that was set/found, as per normal dict semantics. Thanks @olevinsky.
 
 1.4.1 (2012-12-04)
 ------------------

--- a/modeldict/base.py
+++ b/modeldict/base.py
@@ -94,6 +94,7 @@ class CachedDict(object):
     def setdefault(self, key, value):
         if key not in self:
             self[key] = value
+        return self[key]
 
     def get_default(self, key):
         return NoValue

--- a/modeldict/models.py
+++ b/modeldict/models.py
@@ -92,6 +92,9 @@ class ModelDict(CachedDict):
             defaults={self.value: value},
             **{self.key: key}
         )
+        value = getattr(instance, self.value)
+        self[key] = value
+        return value
 
     def get_default(self, key):
         if not self.auto_create:

--- a/tests/testapp/test_modeldict.py
+++ b/tests/testapp/test_modeldict.py
@@ -162,6 +162,36 @@ class ModelDictTest(TransactionTestCase):
         self.assertEquals(len(mydict), 11)
         self.assertEquals(mydict['hello'], 'bar2')
 
+    def test_setdefault(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value')
+
+        with self.assertRaises(KeyError):
+            mydict['hello']
+
+        ret = mydict.setdefault('hello', 'world')
+        self.assertEqual(ret, 'world')
+        self.assertEqual(mydict['hello'], 'world')
+
+        ret = mydict.setdefault('hello', 'world2')
+        self.assertEqual(ret, 'world')
+        self.assertEqual(mydict['hello'], 'world')
+
+    def test_setdefault_instances(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value')
+
+        with self.assertRaises(KeyError):
+            mydict['hello']
+
+        instance = ModelDictModel(key='hello', value='world')
+        ret = mydict.setdefault('hello', instance)
+        self.assertEqual(ret, 'world')
+        self.assertEqual(mydict['hello'], 'world')
+
+        instance2 = ModelDictModel(key='hello', value='world2')
+        ret = mydict.setdefault('hello', instance2)
+        self.assertEqual(ret, 'world')
+        self.assertEqual(mydict['hello'], 'world')
+
     def test_django_signals_are_connected(self):
         from django.db.models.signals import post_save, post_delete
         from django.core.signals import request_finished


### PR DESCRIPTION
Matches normal dict semantics.

Adapted from disqus/django-modeldict#2, thanks @olevinsky.