### PR TITLE
Tests - add coverage check

### DIFF
--- a/modeldict/base.py
+++ b/modeldict/base.py
@@ -1,6 +1,7 @@
 import time
 
 from django.core.cache import cache
+from django.utils import six
 
 NoValue = object()
 
@@ -57,15 +58,15 @@ class CachedDict(object):
 
     def iteritems(self):
         self._populate()
-        return self._local_cache.iteritems()
+        return six.iteritems(self._local_cache)
 
     def itervalues(self):
         self._populate()
-        return self._local_cache.itervalues()
+        return six.itervalues(self._local_cache)
 
     def iterkeys(self):
         self._populate()
-        return self._local_cache.iterkeys()
+        return six.iterkeys(self._local_cache)
 
     def keys(self):
         return list(self.iterkeys())
@@ -86,8 +87,9 @@ class CachedDict(object):
 
         try:
             del self[key]
-        except KeyError:
-            pass
+        except KeyError:  # pragma: no cover
+            # Concurrent edit
+            pass  # pragma: no cover
 
         return value
 

--- a/modeldict/models.py
+++ b/modeldict/models.py
@@ -5,8 +5,9 @@ from .base import CachedDict, NoValue
 
 try:
     from celery.signals import task_postrun
-except ImportError:  # celery must not be installed
-    has_celery = False
+except ImportError:  # pragma: no cover
+    # celery must not be installed
+    has_celery = False  # pragma: no cover
 else:
     has_celery = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
 [wheel]
 universal = 1
 
+[pytest]
+addopts = --cov modeldict
+          --cov-report term-missing
+          --cov-fail-under 80
+
 [flake8]
 max-line-length = 120

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,7 @@ amqp==1.4.9
 anyjson==0.3.3
 billiard==3.3.0.22
 celery==3.1.19
+coverage==4.0.3
 docutils==0.12
 flake8==2.5.1
 funcsigs==0.4
@@ -14,7 +15,8 @@ pep8==1.7.0
 py==1.4.31
 pyflakes==1.0.0
 Pygments==2.0.2
-pytest==2.8.5
+pytest-cov==2.2.1
 pytest-django==2.9.1
+pytest==2.8.5
 pytz==2015.7
 six==1.10.0

--- a/tests/testapp/test_base.py
+++ b/tests/testapp/test_base.py
@@ -1,0 +1,18 @@
+import pytest
+from django.test import SimpleTestCase
+from modeldict.base import CachedDict
+
+
+class CachedDictTest(SimpleTestCase):
+
+    def test_setitem_not_implemented(self):
+        d = CachedDict()
+
+        with pytest.raises(NotImplementedError):
+            d['x'] = 'foo'
+
+    def test_delitem_not_implemented(self):
+        d = CachedDict()
+
+        with pytest.raises(NotImplementedError):
+            del d['x']

--- a/tests/testapp/test_modeldict.py
+++ b/tests/testapp/test_modeldict.py
@@ -92,6 +92,63 @@ class ModelDictTest(TransactionTestCase):
         mydict['foo'].delete()
         self.assertTrue('foo' not in mydict)
 
+    def test_modeldict_instances_auto_create(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value', instances=True, auto_create=True)
+
+        obj = mydict['foo']
+        assert isinstance(obj, ModelDictModel)
+        assert obj.value == ''
+
+    def test_modeldict_len_empty(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value')
+        assert len(mydict) == 0
+
+    def test_modeldict_len_one(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value')
+        mydict['hello'] = 'world'
+        assert len(mydict) == 1
+
+    def test_modeldict_len_two(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value')
+        mydict['hello'] = 'world'
+        mydict['hi'] = 'world'
+        assert len(mydict) == 2
+
+    def test_modeldict_iter(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value')
+        mydict['hello'] = 'world'
+        assert next(iter(mydict)) == 'hello'
+
+    def test_modeldict_iteritems(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value')
+        mydict['hello'] = 'world'
+        assert list(mydict.iteritems()) == [('hello', 'world')]
+
+    def test_modeldict_itervalues(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value')
+        mydict['hello'] = 'world'
+        assert list(mydict.itervalues()) == ['world']
+
+    def test_modeldict_iterkeys(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value')
+        mydict['hello'] = 'world'
+        assert list(mydict.iterkeys()) == ['hello']
+
+    def test_modeldict_keys(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value')
+        mydict['hello'] = 'world'
+        assert list(mydict.keys()) == ['hello']
+
+    def test_modeldict_values(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value')
+        mydict['hello'] = 'world'
+        assert list(mydict.values()) == ['world']
+
+    def test_modeldict_items(self):
+        mydict = ModelDict(ModelDictModel, key='key', value='value')
+        mydict['hello'] = 'world'
+        assert list(mydict.items()) == [('hello', 'world')]
+
     def test_modeldict_expirey(self):
         base_count = ModelDictModel.objects.count()
 


### PR DESCRIPTION
Use `pytest-cov` to determine coverage, fail if it's less than 80% (the redis code is bringing us down), and add some tests to bump it up a bit.

Also improves Python 3 compatibility.