### PR TITLE
Fix missed invalid

### DIFF
--- a/modeldict/base.py
+++ b/modeldict/base.py
@@ -131,7 +131,7 @@ class CachedDict(object):
 
         return (
             self._local_last_updated is None or
-            int(remote_last_updated) > self._local_last_updated
+            int(remote_last_updated) >= self._local_last_updated
         )
 
     def get_cache_data(self):

--- a/modeldict/base.py
+++ b/modeldict/base.py
@@ -54,7 +54,7 @@ class CachedDict(object):
         return iter(self._local_cache)
 
     def __repr__(self):
-        return "<%s: %s>" % (self.__class__.__name__, self.model.__name__)
+        return "<%s>" % (self.__class__.__name__,)
 
     def iteritems(self):
         self._populate()

--- a/modeldict/base.py
+++ b/modeldict/base.py
@@ -183,12 +183,12 @@ class CachedDict(object):
             if local_cache_is_invalid or local_cache_is_invalid is None:
                 self._local_cache = self.remote_cache.get(self.remote_cache_key)
 
+                # We've updated from remote, so mark ourselves as
+                # such so that we won't expire until the next timeout
+                self._local_last_updated = now
+
             # We last checked for remote changes just now
             self._last_checked_for_remote_changes = now
-
-            # No matter what, we've updated from remote, so mark ourselves as
-            # such so that we won't expire until the next timeout
-            self._local_last_updated = now
 
         # Update from cache if local_cache is still empty
         if self._local_cache is None:

--- a/modeldict/models.py
+++ b/modeldict/models.py
@@ -85,6 +85,9 @@ class ModelDict(CachedDict):
         self.model._default_manager.filter(**{self.key: key}).delete()
         # self._populate(reset=True)
 
+    def __repr__(self):
+        return "<%s: %s>" % (self.__class__.__name__, self.model.__name__)
+
     def setdefault(self, key, value):
         if isinstance(value, self.model):
             value = getattr(value, self.value)

--- a/tests/testapp/test_modeldict.py
+++ b/tests/testapp/test_modeldict.py
@@ -434,6 +434,33 @@ class CachedDictTest(TestCase):
         )
         assert result
 
+    def test_is_invalid_if_local_cache_is_none(self):
+        self.mydict._local_cache = None
+        assert self.mydict.local_cache_is_invalid()
+
+    def test_is_invalid_if_remote_cache_updated_right_after_local_last_updated(self):
+        cache.clear()
+        mydict = CachedDict(timeout=100)
+
+        mydict.remote_cache.set_many({
+            mydict.remote_cache_key: {'MYFLAG': 'value1'},
+            mydict.remote_cache_last_updated_key: 12345
+        })
+
+        # load the local cache from remote cache
+        # this sets: mydict._local_last_updated = int(time.time())
+        mydict._populate()
+
+        # simulate remote cache updated by external process
+        # time is rounded again in remote_cache:
+        # remote_cache[remote_cache_last_updated_key] = int(time.time())
+        mydict.remote_cache.set_many({
+            mydict.remote_cache_key: {'MYFLAG': 'value2'},
+            mydict.remote_cache_last_updated_key: int(time.time())
+        })
+
+        assert mydict.local_cache_is_invalid()
+
     def test_populate_timeout(self):
         cache.clear()
         mydict = CachedDict(timeout=100)

--- a/tests/testapp/test_modeldict.py
+++ b/tests/testapp/test_modeldict.py
@@ -447,8 +447,10 @@ class CachedDictTest(TestCase):
         # load the local cache from remote cache
         mydict._populate()
 
-        mydict.remote_cache.set(mydict.remote_cache_key, {'MYFLAG': 'value2'})
-        mydict.remote_cache.set(mydict.remote_cache_last_updated_key, now + 1)
+        mydict.remote_cache.set_many({
+            mydict.remote_cache_key: {'MYFLAG': 'value2'},
+            mydict.remote_cache_last_updated_key: now + 1
+        })
 
         # before timeout: local cache should not be updated
         with mock.patch('time.time', mock.Mock(return_value=now + mydict.timeout - 1)):


### PR DESCRIPTION
Hi. This extends https://github.com/YPlan/django-modeldict/pull/20 by fixing a few extra issues that where causing web server processes to usually miss cache updates while processing several requests per second (see https://github.com/YPlan/gargoyle/issues/83). The fixed issues are:

* `CachedDict._local_last_updated` being set even if local_cache was not updated (similar to https://github.com/YPlan/django-modeldict/pull/20), which may affect calculation of `CachedDict.local_cache_is_invalid()`.
* Time comparison in `CachedDict.local_cache_is_invalid()` would return a false negative if remote cache is updated within the same second as `CachedDict._local_last_updated`, due to time being rounded as `int()`. The chances of this were made bigger by the previous issue together with the `request_finished` handler constantly expiring the local cache.
* Failing tests crashing due to undefined `model` variable in `CachedDict.__repr__()`.