### PR TITLE
Stop rounding time.time() down

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending release
 ---------------
 
 * New release notes here
+* Stop rounding ``time.time()`` down to the nearest integer, so we are more fine grained around expiration. It might
+  also fix a subtle timing bug around re-fetching the remote cache unnecessarily.
 
 1.5.2 (2016-07-31)
 ------------------

--- a/modeldict/base.py
+++ b/modeldict/base.py
@@ -131,7 +131,7 @@ class CachedDict(object):
 
         return (
             self._local_last_updated is None or
-            int(remote_last_updated) >= self._local_last_updated
+            remote_last_updated > self._local_last_updated
         )
 
     def get_cache_data(self):
@@ -161,7 +161,7 @@ class CachedDict(object):
 
         - The global cache has expired (via remote_cache_last_updated_key)
         """
-        now = int(time.time())
+        now = time.time()
 
         # If asked to reset, then simply set local cache to None
         if reset:
@@ -199,7 +199,7 @@ class CachedDict(object):
     def _update_cache_data(self):
         self._local_cache = self.get_cache_data()
 
-        now = int(time.time())
+        now = time.time()
         self._local_last_updated = now
         self._last_checked_for_remote_changes = now
 

--- a/tests/testapp/test_modeldict.py
+++ b/tests/testapp/test_modeldict.py
@@ -412,9 +412,9 @@ class CachedDictTest(TestCase):
 
     def test_is_not_expired_if_remote_cache_is_old(self):
         # set it to an expired time
-        self.mydict._local_cache = dict(a=1)
-        self.mydict._local_last_updated = time.time() - 101
-        self.cache.get.return_value = self.mydict._local_last_updated
+        self.mydict._local_cache = {'a': 1}
+        self.mydict._local_last_updated = time.time() - 100
+        self.cache.get.return_value = self.mydict._local_last_updated - 1
 
         result = self.mydict.local_cache_is_invalid()
 
@@ -448,15 +448,14 @@ class CachedDictTest(TestCase):
         })
 
         # load the local cache from remote cache
-        # this sets: mydict._local_last_updated = int(time.time())
+        # this sets: mydict._local_last_updated = time.time()
         mydict._populate()
 
         # simulate remote cache updated by external process
-        # time is rounded again in remote_cache:
-        # remote_cache[remote_cache_last_updated_key] = int(time.time())
+        # remote_cache[remote_cache_last_updated_key] = time.time()
         mydict.remote_cache.set_many({
             mydict.remote_cache_key: {'MYFLAG': 'value2'},
-            mydict.remote_cache_last_updated_key: int(time.time())
+            mydict.remote_cache_last_updated_key: time.time()
         })
 
         assert mydict.local_cache_is_invalid()
@@ -465,7 +464,7 @@ class CachedDictTest(TestCase):
         cache.clear()
         mydict = CachedDict(timeout=100)
 
-        now = int(time.time())
+        now = time.time()
         mydict.remote_cache.set_many({
             mydict.remote_cache_key: {'MYFLAG': 'value1'},
             mydict.remote_cache_last_updated_key: now
@@ -499,7 +498,7 @@ class CachedDictTest(TestCase):
             mydict.remote_cache_last_updated_key: 12345
         })
         # load the local cache from remote cache
-        # this sets: mydict._local_last_updated = int(time.time())
+        # this sets: mydict._local_last_updated = time.time()
         mydict._populate()
         local_last_updated = mydict._local_last_updated
         assert mydict._local_cache == {'MYFLAG': 'value1'}
@@ -507,7 +506,7 @@ class CachedDictTest(TestCase):
         with mock.patch('time.time', mock.Mock(return_value=time.time() + 101)):
             mydict.remote_cache.set_many({
                 mydict.remote_cache_key: {'MYFLAG': 'value2'},
-                mydict.remote_cache_last_updated_key: int(time.time())
+                mydict.remote_cache_last_updated_key: time.time()
             })
             assert mydict.local_cache_has_expired()
             assert mydict.local_cache_is_invalid()
@@ -525,7 +524,7 @@ class CachedDictTest(TestCase):
             mydict.remote_cache_last_updated_key: 12345
         })
         # load the local cache from remote cache
-        # this sets: mydict._local_last_updated = int(time.time())
+        # this sets: mydict._local_last_updated = time.time()
         mydict._populate()
         local_last_updated = mydict._local_last_updated
 


### PR DESCRIPTION
Stop storing `int(time.time())` and instead just store `time.time()`. This means we are more fine grained around expiration and updates, and I'm pretty sure it fixes a subtle bug around registering things as updated remotely when they're not, by removing the `=` from the `>=` comparison, which was added in dc8ea28a392206bdf2c85f47ff56b3bd88c21cbf.

This also fixes one test which wasn't testing what it said it was testing.