### PR TITLE
Fix #176: Ensure that the local cache is reset if the remote cache is cleared

### DIFF
--- a/modeldict/base.py
+++ b/modeldict/base.py
@@ -176,6 +176,9 @@ class CachedDict(object):
                     # We've updated from remote, so mark ourselves as
                     # such so that we won't expire until the next timeout
                     self._local_last_updated = now
+                else:
+                    self._local_cache = None
+                    self._local_last_updated = None
 
             # We last checked for remote changes just now
             self._last_checked_for_remote_changes = now


### PR DESCRIPTION
Per #176, we need to make sure that the local cache gets reset if the remote cache is cleared. This pull request accomplishes that.